### PR TITLE
Added *.rlib to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.a
 *.dummy
 *.o
+*.rlib
 Makefile


### PR DESCRIPTION
A .rlib is built by default, but not ignored by Git like the other library types.
