### PR TITLE
Add target to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.so
 Makefile
 /doc
+/target


### PR DESCRIPTION
Currently, Cargo always recompiles the project, even if nothing has changed. See the commit message for details.

This PR also adds `target` to `.gitignore`.
