### PR TITLE
Update to rustc 1.0.0-nightly (44a287e6e 2015-01-08 17:03:40 -0800)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+rust-stb-image
+==============
+
+Rust bindings to the awesome [stb_image](https://github.com/nothings/stb) library.
+
+Currently using stb_image v1.33.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@
 #![crate_name = "stb_image"]
 #![crate_type = "rlib"]
 
-#![feature(globs)]
-
 extern crate libc;
 
 pub mod stb_image;


### PR DESCRIPTION
- uint -> usize
- update closure syntax
- use CString for ffi

TODO:
- still produces lots of warnings from unstable libs
- still uses (deprecated) arbitrary cargo build command to run make