### PR TITLE
Disable initial values set by `make`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let result = Command::new("make")
-        .args(&["-f", "makefile.cargo"])
+        .args(&["-R", "-f", "makefile.cargo"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()


### PR DESCRIPTION
This fixes cross compilation issues, so it now builds correctly for both Android and ARM.
(See servo/servo#6537)

Part of servo/servo#6327.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-stb-image/78)
<!-- Reviewable:end -->
