### PR TITLE
Fix incorrect vector size when forcing depth on ImageU8.

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -63,6 +63,7 @@ pub fn load_with_depth<T: AsRef<Path>>(path: T, force_depth: usize, convert_hdr:
     let mut width = 0 as c_int;
     let mut height = 0 as c_int;
     let mut depth = 0 as c_int;
+    let force_depth = force_depth as c_int;
     let path_as_cstr = match path.as_ref().as_os_str().to_str() {
 	   Some(s) => match CString::new(s.as_bytes()) {
             Ok(s) => s,
@@ -77,22 +78,24 @@ pub fn load_with_depth<T: AsRef<Path>>(path: T, force_depth: usize, convert_hdr:
 				    &mut width,
 				    &mut height,
 				    &mut depth,
-				    force_depth as c_int);
+				    force_depth);
 	    if buffer.is_null() {
-		LoadResult::Error("stbi_loadf failed".to_string())
+		    LoadResult::Error("stbi_loadf failed".to_string())
 	    } else {
-		LoadResult::ImageF32(load_internal(buffer, width, height, depth))
+        let actual_depth = if force_depth != 0 { force_depth } else { depth };
+		    LoadResult::ImageF32(load_internal(buffer, width, height, actual_depth))
 	    }
 	} else {
 	    let buffer = stbi_load(bytes,
 				   &mut width,
 				   &mut height,
 				   &mut depth,
-				   force_depth as c_int);
+				   force_depth);
 	    if buffer.is_null() {
-		LoadResult::Error("stbi_load failed".to_string())
+		    LoadResult::Error("stbi_load failed".to_string())
 	    } else {
-		LoadResult::ImageU8(load_internal(buffer, width, height, depth))
+        let actual_depth = if force_depth != 0 { force_depth } else { depth };
+		    LoadResult::ImageU8(load_internal(buffer, width, height, actual_depth))
 	    }
 	}
     }
@@ -108,17 +111,18 @@ pub fn load_from_memory_with_depth(buffer: &[u8], force_depth: usize, convert_hd
         let mut width = 0 as c_int;
         let mut height = 0 as c_int;
         let mut depth = 0 as c_int;
+        let force_depth = force_depth as c_int;
         if !convert_hdr && stbi_is_hdr_from_memory(buffer.as_ptr(), buffer.len() as c_int) != 0 {
             let buffer = stbi_loadf_from_memory(buffer.as_ptr(),
                                                 buffer.len() as c_int,
                                                 &mut width,
                                                 &mut height,
                                                 &mut depth,
-                                                force_depth as c_int);
+                                                force_depth);
             if buffer.is_null() {
                 LoadResult::Error("stbi_loadf_from_memory failed".to_string())
             } else {
-                let actual_depth = if force_depth != 0 { force_depth as c_int } else { depth };
+                let actual_depth = if force_depth != 0 { force_depth } else { depth };
                 LoadResult::ImageF32(load_internal(buffer, width, height, actual_depth))
             }
         } else {
@@ -127,11 +131,11 @@ pub fn load_from_memory_with_depth(buffer: &[u8], force_depth: usize, convert_hd
                                                &mut width,
                                                &mut height,
                                                &mut depth,
-                                               force_depth as c_int);
+                                               force_depth);
             if buffer.is_null() {
                 LoadResult::Error("stbi_load_from_memory failed".to_string())
             } else {
-                let actual_depth = if force_depth != 0 { force_depth as c_int } else { depth };
+                let actual_depth = if force_depth != 0 { force_depth } else { depth };
                 LoadResult::ImageU8(load_internal(buffer, width, height, actual_depth))
             }
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -9,26 +9,26 @@
 
 use stb_image::bindgen::*;
 
-use libc::{c_void, c_int};
+use libc::{c_int, c_void};
 use std::convert::AsRef;
 use std::ffi::CString;
 use std::path::Path;
 use std::slice;
 
 pub struct Image<T> {
-    pub width   : usize,
-    pub height  : usize,
-    pub depth   : usize,
-    pub data    : Vec<T>,
+    pub width: usize,
+    pub height: usize,
+    pub depth: usize,
+    pub data: Vec<T>,
 }
 
 impl<T> Image<T> {
     pub fn new(width: usize, height: usize, depth: usize, data: Vec<T>) -> Image<T> {
         Image::<T> {
-            width   : width,
-            height  : height,
-            depth   : depth,
-            data    : data,
+            width: width,
+            height: height,
+            depth: depth,
+            data: data,
         }
     }
 }
@@ -44,60 +44,56 @@ pub fn load<T: AsRef<Path>>(path: T) -> LoadResult {
     load_with_depth(path, force_depth, false)
 }
 
-
 fn load_internal<T: Clone>(buf: *mut T, w: c_int, h: c_int, d: c_int) -> Image<T> {
     unsafe {
         // FIXME: Shouldn't copy; instead we should use a sendable resource. They
         // aren't particularly safe yet though.
         let data = slice::from_raw_parts(buf, (w * h * d) as usize).to_vec();
         stbi_image_free(buf as *mut c_void);
-        Image::<T>{
-            width   : w as usize,
-            height  : h as usize,
-            depth   : d as usize,
-            data    : data}
+        Image::<T> {
+            width: w as usize,
+            height: h as usize,
+            depth: d as usize,
+            data: data,
+        }
     }
 }
 
-pub fn load_with_depth<T: AsRef<Path>>(path: T, force_depth: usize, convert_hdr: bool) -> LoadResult {
+pub fn load_with_depth<T: AsRef<Path>>(
+    path: T,
+    force_depth: usize,
+    convert_hdr: bool,
+) -> LoadResult {
     let mut width = 0 as c_int;
     let mut height = 0 as c_int;
     let mut depth = 0 as c_int;
     let force_depth = force_depth as c_int;
     let path_as_cstr = match path.as_ref().as_os_str().to_str() {
-	   Some(s) => match CString::new(s.as_bytes()) {
+        Some(s) => match CString::new(s.as_bytes()) {
             Ok(s) => s,
-            Err(_) => return LoadResult::Error("path contains null character".to_string())
-       },
-	   None => return LoadResult::Error("path is not valid utf8".to_string()),
+            Err(_) => return LoadResult::Error("path contains null character".to_string()),
+        },
+        None => return LoadResult::Error("path is not valid utf8".to_string()),
     };
     unsafe {
-	let bytes = path_as_cstr.as_ptr();
-	if !convert_hdr && stbi_is_hdr(bytes)!=0   {
-	    let buffer = stbi_loadf(bytes,
-				    &mut width,
-				    &mut height,
-				    &mut depth,
-				    force_depth);
-	    if buffer.is_null() {
-		    LoadResult::Error("stbi_loadf failed".to_string())
-	    } else {
-        let actual_depth = if force_depth != 0 { force_depth } else { depth };
-		    LoadResult::ImageF32(load_internal(buffer, width, height, actual_depth))
-	    }
-	} else {
-	    let buffer = stbi_load(bytes,
-				   &mut width,
-				   &mut height,
-				   &mut depth,
-				   force_depth);
-	    if buffer.is_null() {
-		    LoadResult::Error("stbi_load failed".to_string())
-	    } else {
-        let actual_depth = if force_depth != 0 { force_depth } else { depth };
-		    LoadResult::ImageU8(load_internal(buffer, width, height, actual_depth))
-	    }
-	}
+        let bytes = path_as_cstr.as_ptr();
+        if !convert_hdr && stbi_is_hdr(bytes) != 0 {
+            let buffer = stbi_loadf(bytes, &mut width, &mut height, &mut depth, force_depth);
+            if buffer.is_null() {
+                LoadResult::Error("stbi_loadf failed".to_string())
+            } else {
+                let actual_depth = if force_depth != 0 { force_depth } else { depth };
+                LoadResult::ImageF32(load_internal(buffer, width, height, actual_depth))
+            }
+        } else {
+            let buffer = stbi_load(bytes, &mut width, &mut height, &mut depth, force_depth);
+            if buffer.is_null() {
+                LoadResult::Error("stbi_load failed".to_string())
+            } else {
+                let actual_depth = if force_depth != 0 { force_depth } else { depth };
+                LoadResult::ImageU8(load_internal(buffer, width, height, actual_depth))
+            }
+        }
     }
 }
 
@@ -106,19 +102,25 @@ pub fn load_from_memory(buffer: &[u8]) -> LoadResult {
     load_from_memory_with_depth(buffer, force_depth, false)
 }
 
-pub fn load_from_memory_with_depth(buffer: &[u8], force_depth: usize, convert_hdr:bool) -> LoadResult {
+pub fn load_from_memory_with_depth(
+    buffer: &[u8],
+    force_depth: usize,
+    convert_hdr: bool,
+) -> LoadResult {
     unsafe {
         let mut width = 0 as c_int;
         let mut height = 0 as c_int;
         let mut depth = 0 as c_int;
         let force_depth = force_depth as c_int;
         if !convert_hdr && stbi_is_hdr_from_memory(buffer.as_ptr(), buffer.len() as c_int) != 0 {
-            let buffer = stbi_loadf_from_memory(buffer.as_ptr(),
-                                                buffer.len() as c_int,
-                                                &mut width,
-                                                &mut height,
-                                                &mut depth,
-                                                force_depth);
+            let buffer = stbi_loadf_from_memory(
+                buffer.as_ptr(),
+                buffer.len() as c_int,
+                &mut width,
+                &mut height,
+                &mut depth,
+                force_depth,
+            );
             if buffer.is_null() {
                 LoadResult::Error("stbi_loadf_from_memory failed".to_string())
             } else {
@@ -126,12 +128,14 @@ pub fn load_from_memory_with_depth(buffer: &[u8], force_depth: usize, convert_hd
                 LoadResult::ImageF32(load_internal(buffer, width, height, actual_depth))
             }
         } else {
-            let buffer = stbi_load_from_memory(buffer.as_ptr(),
-                                               buffer.len() as c_int,
-                                               &mut width,
-                                               &mut height,
-                                               &mut depth,
-                                               force_depth);
+            let buffer = stbi_load_from_memory(
+                buffer.as_ptr(),
+                buffer.len() as c_int,
+                &mut width,
+                &mut height,
+                &mut depth,
+                force_depth,
+            );
             if buffer.is_null() {
                 LoadResult::Error("stbi_load_from_memory failed".to_string())
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,5 @@
 
 extern crate libc;
 
-pub mod stb_image;
 pub mod image;
-
+pub mod stb_image;

--- a/src/stb_image.rs
+++ b/src/stb_image.rs
@@ -35,65 +35,73 @@ pub mod bindgen {
 
     extern "C" {
 
-        pub fn stbi_load_from_memory(buffer: *const stbi_uc,
-                                     len: c_int,
-                                     x: *mut c_int,
-                                     y: *mut c_int,
-                                     comp: *mut c_int,
-                                     req_comp: c_int)
-                                     -> *mut stbi_uc;
+        pub fn stbi_load_from_memory(
+            buffer: *const stbi_uc,
+            len: c_int,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut stbi_uc;
 
-        pub fn stbi_load(filename: *const c_char,
-                         x: *mut c_int,
-                         y: *mut c_int,
-                         comp: *mut c_int,
-                         req_comp: c_int)
-                         -> *mut stbi_uc;
+        pub fn stbi_load(
+            filename: *const c_char,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut stbi_uc;
 
-        pub fn stbi_load_from_file(f: *mut FILE,
-                                   x: *mut c_int,
-                                   y: *mut c_int,
-                                   comp: *mut c_int,
-                                   req_comp: c_int)
-                                   -> *mut stbi_uc;
+        pub fn stbi_load_from_file(
+            f: *mut FILE,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut stbi_uc;
 
-        pub fn stbi_load_from_callbacks(clbk: *const stbi_io_callbacks,
-                                        user: *mut c_void,
-                                        x: *mut c_int,
-                                        y: *mut c_int,
-                                        comp: *mut c_int,
-                                        req_comp: c_int)
-                                        -> *mut stbi_uc;
+        pub fn stbi_load_from_callbacks(
+            clbk: *const stbi_io_callbacks,
+            user: *mut c_void,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut stbi_uc;
 
-        pub fn stbi_loadf_from_memory(buffer: *const stbi_uc,
-                                      len: c_int,
-                                      x: *mut c_int,
-                                      y: *mut c_int,
-                                      comp: *mut c_int,
-                                      req_comp: c_int)
-                                      -> *mut c_float;
+        pub fn stbi_loadf_from_memory(
+            buffer: *const stbi_uc,
+            len: c_int,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut c_float;
 
-        pub fn stbi_loadf(filename: *const c_char,
-                          x: *mut c_int,
-                          y: *mut c_int,
-                          comp: *mut c_int,
-                          req_comp: c_int)
-                          -> *mut c_float;
+        pub fn stbi_loadf(
+            filename: *const c_char,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut c_float;
 
-        pub fn stbi_loadf_from_file(f: *mut FILE,
-                                    x: *mut c_int,
-                                    y: *mut c_int,
-                                    comp: *mut c_int,
-                                    req_comp: c_int)
-                                    -> *mut c_float;
+        pub fn stbi_loadf_from_file(
+            f: *mut FILE,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut c_float;
 
-        pub fn stbi_loadf_from_callbacks(clbk: *const stbi_io_callbacks,
-                                         user: *mut c_void,
-                                         x: *mut c_int,
-                                         y: *mut c_int,
-                                         comp: *mut c_int,
-                                         req_comp: c_int)
-                                         -> *mut c_float;
+        pub fn stbi_loadf_from_callbacks(
+            clbk: *const stbi_io_callbacks,
+            user: *mut c_void,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+            req_comp: c_int,
+        ) -> *mut c_float;
 
         pub fn stbi_hdr_to_ldr_gamma(gamma: c_float);
 
@@ -103,9 +111,10 @@ pub mod bindgen {
 
         pub fn stbi_ldr_to_hdr_scale(scale: c_float);
 
-        pub fn stbi_is_hdr_from_callbacks(clbk: *const stbi_io_callbacks,
-                                          user: *mut c_void)
-                                          -> c_int;
+        pub fn stbi_is_hdr_from_callbacks(
+            clbk: *const stbi_io_callbacks,
+            user: *mut c_void,
+        ) -> c_int;
 
         pub fn stbi_is_hdr_from_memory(buffer: *const stbi_uc, len: c_int) -> c_int;
 
@@ -117,63 +126,72 @@ pub mod bindgen {
 
         pub fn stbi_image_free(retval_from_stbi_load: *mut c_void);
 
-        pub fn stbi_info_from_memory(buffer: *const stbi_uc,
-                                     len: c_int,
-                                     x: *mut c_int,
-                                     y: *mut c_int,
-                                     comp: *mut c_int)
-                                     -> c_int;
+        pub fn stbi_info_from_memory(
+            buffer: *const stbi_uc,
+            len: c_int,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+        ) -> c_int;
 
-        pub fn stbi_info_from_callbacks(clbk: *const stbi_io_callbacks,
-                                        user: *mut c_void,
-                                        x: *mut c_int,
-                                        y: *mut c_int,
-                                        comp: *mut c_int)
-                                        -> c_int;
+        pub fn stbi_info_from_callbacks(
+            clbk: *const stbi_io_callbacks,
+            user: *mut c_void,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+        ) -> c_int;
 
-        pub fn stbi_info(filename: *const c_char,
-                         x: *mut c_int,
-                         y: *mut c_int,
-                         comp: *mut c_int)
-                         -> c_int;
+        pub fn stbi_info(
+            filename: *const c_char,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+        ) -> c_int;
 
-        pub fn stbi_info_from_file(f: *mut FILE,
-                                   x: *mut c_int,
-                                   y: *mut c_int,
-                                   comp: *mut c_int)
-                                   -> c_int;
+        pub fn stbi_info_from_file(
+            f: *mut FILE,
+            x: *mut c_int,
+            y: *mut c_int,
+            comp: *mut c_int,
+        ) -> c_int;
 
         pub fn stbi_set_unpremultiply_on_load(flag_true_if_should_unpremultiply: c_int);
 
         pub fn stbi_convert_iphone_png_to_rgb(flag_true_if_should_convert: c_int);
 
-        pub fn stbi_zlib_decode_malloc_guesssize(buffer: *const c_char,
-                                                 len: c_int,
-                                                 initial_size: c_int,
-                                                 outlen: *mut c_int)
-                                                 -> *mut c_char;
+        pub fn stbi_zlib_decode_malloc_guesssize(
+            buffer: *const c_char,
+            len: c_int,
+            initial_size: c_int,
+            outlen: *mut c_int,
+        ) -> *mut c_char;
 
-        pub fn stbi_zlib_decode_malloc(buffer: *const c_char,
-                                       len: c_int,
-                                       outlen: *mut c_int)
-                                       -> *mut c_char;
+        pub fn stbi_zlib_decode_malloc(
+            buffer: *const c_char,
+            len: c_int,
+            outlen: *mut c_int,
+        ) -> *mut c_char;
 
-        pub fn stbi_zlib_decode_buffer(obuffer: *const c_char,
-                                       olen: c_int,
-                                       ibuffer: *const c_char,
-                                       ilen: c_int)
-                                       -> c_int;
+        pub fn stbi_zlib_decode_buffer(
+            obuffer: *const c_char,
+            olen: c_int,
+            ibuffer: *const c_char,
+            ilen: c_int,
+        ) -> c_int;
 
-        pub fn stbi_zlib_decode_noheader_malloc(buffer: *const c_char,
-                                                len: c_int,
-                                                outlen: *mut c_int)
-                                                -> *mut c_char;
+        pub fn stbi_zlib_decode_noheader_malloc(
+            buffer: *const c_char,
+            len: c_int,
+            outlen: *mut c_int,
+        ) -> *mut c_char;
 
-        pub fn stbi_zlib_decode_noheader_buffer(obuffer: *mut c_char,
-                                                olen: c_int,
-                                                ibuffer: *const c_char,
-                                                ilen: c_int)
-                                                -> c_int;
+        pub fn stbi_zlib_decode_noheader_buffer(
+            obuffer: *mut c_char,
+            olen: c_int,
+            ibuffer: *const c_char,
+            ilen: c_int,
+        ) -> c_int;
 
         pub fn stbi_set_flip_vertically_on_load(flag_true_if_should_flip: i32);
 


### PR DESCRIPTION
stbi_load* functions report the depth that the loaded image would have
had if it had not been forced. We must use the forced depth value when
making a Vec from the raw buffer, otherwise we may either not use the
whole buffer or overrun the buffer and crash.