### PR TITLE
Version 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stb_image"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the stb image encoding/decoding library"
 repository = "https://github.com/servo/rust-stb-image"


### PR DESCRIPTION
* Fix incorrect vector size when forcing depth on ImageU8. (#96)