### PR TITLE
Update from ancient gcc dependency to cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ build = "build.rs"
 libc = "0.2.0"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1"

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate gcc;
-
 fn main() {
-    gcc::compile_library("libstb_image.a", &["src/stb_image.c"]);
+    let mut build = cc::Build::new();
+    
+    build
+        .cpp(true)
+        .file("src/stb_image.c");
+
+    build.compile("libstb_image");
 }


### PR DESCRIPTION
`gcc` was stuck in my dependency tree for a while, and this was the last remaining crate to use it. `gcc` has been renamed into `cc` and has seen significant improvements since then.

The reason I've updated it now is because `gcc` didn't pick up our build environment properly while `cc` does.