### PR TITLE
fix null pointer dereference in stb_image.h

### DIFF
--- a/src/stb_image.c
+++ b/src/stb_image.c
@@ -5408,7 +5408,7 @@ static stbi_uc *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int re
 
    if (!stbi__pic_load_core(s,x,y,comp, result)) {
       STBI_FREE(result);
-      result=0;
+      return 0;
    }
    *px = x;
    *py = y;


### PR DESCRIPTION
Related issue: https://github.com/libsixel/libsixel/issues/73 & https://github.com/nothings/stb/issues/1452

Specifically, if the `stbi__pic_load_core` function returns 0 (line 5409), `result` will be released (line 5410) and set to 0 (line 5411). This null pointer will be dereferenced in `stbi__convert_format` (line 5416), which would crash the application.

https://github.com/servo/rust-stb-image/blob/90bce374ef8ccebbe112d71e2e7b5b8aaf3add39/src/stb_image.c#L5409-L5416