### PR TITLE
README: Update stb_image version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ Rust bindings to the awesome [stb_image](https://github.com/nothings/stb) librar
 
 [Documentation](https://docs.rs/stb_image/)
 
-Currently using stb_image v1.33.
+Currently using a [modified][GH102] version of stb_image v2.06.
+
+[GH102]: https://github.com/servo/rust-stb-image/commit/2432751b8cf1dfc085b61cb1b07cf3d43d9eeb9a


### PR DESCRIPTION
Currently the README file says

> Currently using stb_image v1.33

which has not been accurate since the vendored C library was updated to version 2.06 in commit f3bb83b783b53c1ecdbf4bbe0aed3cb65f0ce3c8.

This patch updates the README file to say "v2.06" and to mention that the vendored file further was modified in commit 2432751b8cf1dfc085b61cb1b07cf3d43d9eeb9a.